### PR TITLE
Fix some Firefox layout issues.

### DIFF
--- a/src/client/mtna/archive-template.jade
+++ b/src/client/mtna/archive-template.jade
@@ -16,10 +16,9 @@ div.relative(role="main"
   md-content.md-default-theme( flex md-scroll-y elem-click="state.collapse()" )
     // main content
 
-    md-card(
+    md-card.firefox-tweak(
       ng-if="state.pre.length > 0"
       flex-gt-sm="90" flex-gt-md="80"
-      class="firefox-tweak"
     )
       md-list
         md-subheader.md-no-sticky(ng-repeat-start="(key,value) in state.pre | groupBy: 'family' ")
@@ -31,8 +30,8 @@ div.relative(role="main"
             )
         md-divider(ng-repeat-end)
 
-    md-card.md-padding(
-      ng-if="state.current" flex-gt-sm="95" flex-gt-md="85" class="firefox-tweak"
+    md-card.md-padding.firefox-tweak(
+      ng-if="state.current" flex-gt-sm="95" flex-gt-md="85"
     )
       record-viewer(
         record="state.current"

--- a/src/client/mtna/archive-template.jade
+++ b/src/client/mtna/archive-template.jade
@@ -19,6 +19,7 @@ div.relative(role="main"
     md-card(
       ng-if="state.pre.length > 0"
       flex-gt-sm="90" flex-gt-md="80"
+      class="firefox-tweak"
     )
       md-list
         md-subheader.md-no-sticky(ng-repeat-start="(key,value) in state.pre | groupBy: 'family' ")
@@ -31,7 +32,7 @@ div.relative(role="main"
         md-divider(ng-repeat-end)
 
     md-card.md-padding(
-      ng-if="state.current" flex-gt-sm="95" flex-gt-md="85"
+      ng-if="state.current" flex-gt-sm="95" flex-gt-md="85" class="firefox-tweak"
     )
       record-viewer(
         record="state.current"

--- a/src/client/mtna/archive-template.jade
+++ b/src/client/mtna/archive-template.jade
@@ -39,7 +39,7 @@ div.relative(role="main"
         done-editing="state.save(state.current)"
       )
 
-    md-card(
+    md-card.firefox-tweak(
       ng-if="state.post.length > 0"
       flex-gt-sm="90" flex-gt-md="80"
     )

--- a/src/client/util/table.scss
+++ b/src/client/util/table.scss
@@ -3,6 +3,10 @@ $grey_400: #ddd;
 $grey_138: rgb(138, 138, 138);
 $grey_33: rgb(33, 33, 33);
 
+.firefox-tweak {
+  max-height: inherit;
+}
+
 table.mtna-table {
   border: 0;
   border-collapse: collapse;


### PR DESCRIPTION
This tweaks a bug with firefox's rendering of md-card. Basically, there is a css prop that sets max height to 100%. Firefox interprets this as the height of the visible viewport rather than 'what is needed', or whatever chrome actually is. By setting this value to inherit, the height is automatically inherited. This works in chrome and firefox.