### PR TITLE
Correct travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,19 @@
 language: node_js
 node_js:
-- '4.1'
-
-dependencies:
-  pre:
-  - gem install package_cloud fpm
+- '6.2'
 
 before_install:
+- gem install package_cloud fpm
 - export DISPLAY=:99.0
 - sh -e /etc/init.d/xvfb start
 
 before_deploy: "./package.sh"
-deployment:
+
+deploy:
+  provider: script
   skip_cleanup: true
-  production:
-    branch: master
-    commands:
-    - package_cloud push PronghornDigital/mtna/os/version ./*.rpm
+  branch: master
+  script: package_cloud push PronghornDigital/mtna/os/version ./*.rpm
 env:
   global:
     secure: JOnsQ5Wy3mlic/zSTMLSh+qkWQBruQKSa8WDCbeofoV8RLW2IWuxHiveHhzdUyioIx4Ih+iZ/9I2d5q6/13l5ew/FhHgbYTJtrJXkuum5qYJdVUrJrGlnosPAEBCORYAedRyNad/2Jq0YVK3ZLMYcl43IvMlPxpknRfhBd+EmhGtUWjYX/PCcToiBWJAIPj7ucPnN4Xm90wVQ9SQJJRjRTzvTpzP2iS0t/FQQFm+mznNyghKaK+9pONGmFW5n8BHpA6wAMrO3arB6AoLcespQK9gOz6WSCMfyMyMNWi+gw1WFrv19oV3uDw2ty5Tb2GfjTJzY7m0weeUK1tPOegodA64n3ct9xMi8f+XtcyPNF1zlrkh8cj51wYm9a59+OG4/CoQc6gPO9zuvkZOAsVV4FCk6KTtV3yzrdJyV5oy2TfmdmKH7/cv+frEb3IEO3nsKIUdF8s/n52VhOfPvj8LiTZNBOdoDvp25g5mHTxCfMBWwfWonjU1x6a4i+egJILpZmQHFmMvUxxkqgUVD6HE5ZI3xJuOXNP2AGKp0COByFXkQqP4e2LTwRGhLrxYLUflrs7TpslM3k14sSBBuw3XrPHh5cKKNwFGx6yxVjqIU4nTOKbwsjS+svD9guLBdWF9L9Gyq2U2mBeXugX9EKgGlRFZxrE49SofhrzUc6mhjMo=

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Montana News Archive
+# Montana News Archive [![Build Status](https://travis-ci.org/PronghornDigital/Montana-News-Archive.svg?branch=master)](https://travis-ci.org/PronghornDigital/Montana-News-Archive)
 
 ## Development
 

--- a/package.sh
+++ b/package.sh
@@ -36,4 +36,7 @@ fpm -s dir -t rpm \
     --description "${description}" \
     --prefix "$install_prefix" \
     dist/ \
+    node_modules/ \
+    package.json \
+    gulpfile.js \
     README.md


### PR DESCRIPTION
- Deployment config was using the old travis api.
- Add the CI status badge to the readme.
- Include node_modules in the package release.
- Bump CI node version to 6.2, the latest stable release.