### PR TITLE
Correct RPM push command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ language: node_js
 node_js:
 - '6.2'
 
+addons:
+  apt:
+    packages:
+    - rpm
+
 before_install:
 - gem install package_cloud fpm
 - export DISPLAY=:99.0
@@ -13,7 +18,7 @@ deploy:
   provider: script
   skip_cleanup: true
   branch: master
-  script: package_cloud push PronghornDigital/mtna/os/version ./*.rpm
+  script: ./release.sh
 env:
   global:
     secure: JOnsQ5Wy3mlic/zSTMLSh+qkWQBruQKSa8WDCbeofoV8RLW2IWuxHiveHhzdUyioIx4Ih+iZ/9I2d5q6/13l5ew/FhHgbYTJtrJXkuum5qYJdVUrJrGlnosPAEBCORYAedRyNad/2Jq0YVK3ZLMYcl43IvMlPxpknRfhBd+EmhGtUWjYX/PCcToiBWJAIPj7ucPnN4Xm90wVQ9SQJJRjRTzvTpzP2iS0t/FQQFm+mznNyghKaK+9pONGmFW5n8BHpA6wAMrO3arB6AoLcespQK9gOz6WSCMfyMyMNWi+gw1WFrv19oV3uDw2ty5Tb2GfjTJzY7m0weeUK1tPOegodA64n3ct9xMi8f+XtcyPNF1zlrkh8cj51wYm9a59+OG4/CoQc6gPO9zuvkZOAsVV4FCk6KTtV3yzrdJyV5oy2TfmdmKH7/cv+frEb3IEO3nsKIUdF8s/n52VhOfPvj8LiTZNBOdoDvp25g5mHTxCfMBWwfWonjU1x6a4i+egJILpZmQHFmMvUxxkqgUVD6HE5ZI3xJuOXNP2AGKp0COByFXkQqP4e2LTwRGhLrxYLUflrs7TpslM3k14sSBBuw3XrPHh5cKKNwFGx6yxVjqIU4nTOKbwsjS+svD9guLBdWF9L9Gyq2U2mBeXugX9EKgGlRFZxrE49SofhrzUc6mhjMo=

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if [ -z "$TRAVIS_BUILD_NUMBER" ]; then
+  echo "TRAVIS_BUILD_NUMBER is not set. Please do not push locally built packages outside of the CI pipeline."
+  exit 1
+fi
+
+package_cloud version
+package_cloud push PronghornDigital/mtna/fedora/23 ./*.rpm
+package_cloud push PronghornDigital/mtna/fedora/24 ./*.rpm


### PR DESCRIPTION
- Moves the release action into `release.sh`
- Installs missing RPM dependency
- Pushed RPM for F23 and F24

Unfortunately, there is now way to push a generic package to packagecloud. So, I am pushing both an F23 and an F24 package. They are the same package.