### PR TITLE
Nix Search Results Message and Add Docs Link

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mtna",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Montana / KTVQ2 Video Archive Management.",
   "repository": {
     "type": "git",

--- a/src/client/mtna/archive-template.jade
+++ b/src/client/mtna/archive-template.jade
@@ -24,17 +24,6 @@ div.relative(role="main"
       p.lead
         small Hint! You can save your searches by bookmarking the page.
 
-    div.welcome(ng-if="state.hasSearch || state.records.length != 0")
-      p.lead
-        | You've found
-        strong  {{ state.records.length }}
-        |  record{{ state.records.length == 1 ? '' : 's'}} searching for
-        strong  {{ state._location._queryString == "" ? "all records" : state._location._queryString  }}
-        |  from
-        strong  {{ state._location._startDate == "" ? "the beginning of history" : state._location._startDate | date:'MMM d, y' }}
-        |  to
-        strong  {{ state._location._endDate == "" ? "the end of time" : state._location._endDate | date:'MMM d, y'  }}.
-
       p.lead(ng-if="state.records.length > 350")
         small (That's a lot! Opening records could be a tag sluggish.)
 

--- a/src/client/mtna/archive-template.jade
+++ b/src/client/mtna/archive-template.jade
@@ -22,10 +22,17 @@ div.relative(role="main"
       p.lead Welcome to the archives!
       p.lead To get started, click the blue bar to start a search, or click the "+" icon below to add a record.
       p.lead
+        | Documentation is available at
+        a(href="http://mtnewsarchive.net" target="blank")  mtnewsarchive.net
+        
+      p.lead
         small Hint! You can save your searches by bookmarking the page.
 
       p.lead(ng-if="state.records.length > 350")
         small (That's a lot! Opening records could be a tag sluggish.)
+    
+    div.welcome(ng-if="state.hasSearch && state.records.length == 0")
+      p.lead No records found.
 
     md-card.firefox-tweak(
       ng-if="state.pre.length > 0"

--- a/src/client/mtna/searchbar/searchbar-template.jade
+++ b/src/client/mtna/searchbar/searchbar-template.jade
@@ -2,6 +2,8 @@ md-toolbar(ng-show="!state.searching" ng-click="state.searching = !state.searchi
   .md-toolbar-tools
     h1 MT News Archive
     span(flex)
+    a(href="http://mtnewsarchive.net/docs/" target="blank") 
+      md-icon help
     md-button(aria-label="search")
       md-icon search
 md-toolbar.md-hue-2(ng-show="state.searching")


### PR DESCRIPTION
* Added link to documentation website (mtnewsarchive.net).

* Version bump to 0.2.1

* Nixed search results message from archive-template.jade temporarily because of Issue #129 

```
    div.welcome(ng-if="state.hasSearch || state.records.length != 0")
      p.lead
        | You've found
        strong  {{ state.records.length }}
        |  record{{ state.records.length == 1 ? '' : 's'}} searching for
        strong  {{ state._location._queryString == "" ? "all records" : state._location._queryString  }}
        |  from
        strong  {{ state._location._startDate == "" ? "the beginning of history" : state._location._startDate | date:'MMM d, y' }}
        |  to
        strong  {{ state._location._endDate == "" ? "the end of time" : state._location._endDate | date:'MMM d, y'  }}.

      p.lead(ng-if="state.records.length > 350")
        small (That's a lot! Opening records could be a tad sluggish.)

    div.welcome(ng-if="state.hasSearch || state.records.length != 0")
      p.lead
        | You've found
        strong  {{ state.records.length }}
        |  record{{ state.records.length == 1 ? '' : 's'}} searching for
        strong  {{ state._location._queryString == "" ? "all records" : state._location._queryString  }}
        |  from
        strong  {{ state._location._startDate == "" ? "the beginning of history" : state._location._startDate | date:'MMM d, y' }}
        |  to
        strong  {{ state._location._endDate == "" ? "the end of time" : state._location._endDate | date:'MMM d, y'  }}.

      p.lead(ng-if="state.records.length > 350")
        small (That's a lot! Opening records could be a tad sluggish.)
```