### PR TITLE
Handle various file errors more gracefully

### DIFF
--- a/src/api/record/record.ts
+++ b/src/api/record/record.ts
@@ -43,7 +43,7 @@ export class RecordHandler extends RupertPlugin {
     super();
     readFile(this.dbPath, 'utf-8', (err: any, persisted: string) => {
       if ( err ) {
-        switch (err.code){
+        switch (err.code) {
           case 'EACCESS':
             this.logger.warn(
                 `Invalid permissions to open database at ${this.dbPath}`

--- a/src/api/record/record.ts
+++ b/src/api/record/record.ts
@@ -43,10 +43,21 @@ export class RecordHandler extends RupertPlugin {
     super();
     readFile(this.dbPath, 'utf-8', (err: any, persisted: string) => {
       if ( err ) {
-        this.logger.info(
-            `No database found, creating a new one at ${this.dbPath}`
-        );
-        persisted = '{}';
+        switch (err.code){
+          case 'EACCESS':
+            this.logger.warn(
+                `Invalid permissions to open database at ${this.dbPath}`
+            );
+            break;
+          case 'ENOENT':
+            this.logger.info(
+                `No database found, creating a new one at ${this.dbPath}`
+            );
+            persisted = '{}';
+            break;
+          default:
+            this.logger.error(`Failed to load database due to ${err.code}!`, err);
+        }
       }
       let db = JSON.parse(persisted);
       Object.keys(db).forEach((k: any) => {


### PR DESCRIPTION
This will only create a new persisted database when the file error is ENOENT, that is, the file didn't exist. Any other errors in reading the file should result in a warning (EACCESS) or an error (default).

Fixes #135 