### PR TITLE
Add Circle CI Status Badge to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Montana News Archive [![Build Status](https://travis-ci.org/PronghornDigital/Montana-News-Archive.svg?branch=master)](https://travis-ci.org/PronghornDigital/Montana-News-Archive)
+# Montana News Archive [![CircleCI](https://circleci.com/gh/PronghornDigital/Montana-News-Archive.svg?style=svg)](https://circleci.com/gh/PronghornDigital/Montana-News-Archive)
 
 ## Development
 ### The Easy Way


### PR DESCRIPTION
We migrated off of Travis at the end of 2017.